### PR TITLE
Fix "Add status to current note" command and implement Quick Status Commands

### DIFF
--- a/constants/defaults.ts
+++ b/constants/defaults.ts
@@ -25,6 +25,7 @@ export const DEFAULT_SETTINGS: NoteStatusSettings = {
 	tagPrefix: 'obsidian-note-status',
 	strictStatuses: false, // Default to show all statuses from frontmatter
 	excludeUnknownStatus: true, // Default to exclude unknown status files for better performance
+	quickStatusCommands: ['active', 'completed'], // Add default quick commands
 };
 
 /**

--- a/integrations/settings/settings-ui.ts
+++ b/integrations/settings/settings-ui.ts
@@ -23,6 +23,7 @@ export interface SettingsUICallbacks {
  */
 export class NoteStatusSettingsUI {
   private callbacks: SettingsUICallbacks;
+  private quickCommandsContainer: HTMLElement | null = null;
 
   constructor(callbacks: SettingsUICallbacks) {
     this.callbacks = callbacks;
@@ -67,6 +68,7 @@ export class NoteStatusSettingsUI {
       
       checkbox.addEventListener('change', () => {
         this.callbacks.onTemplateToggle(template.id, checkbox.checked);
+        this.refreshQuickCommandsList(settings);
       });
       
       headerEl.createEl('span', { 
@@ -181,14 +183,24 @@ export class NoteStatusSettingsUI {
         .setDesc('Select which statuses should have dedicated commands in the command palette. These can be assigned hotkeys for quick access.')
         .setHeading();
   
-      const quickCommandsContainer = containerEl.createDiv({ cls: 'quick-commands-container' });
+      this.quickCommandsContainer = containerEl.createDiv({ cls: 'quick-commands-container' });
+      this.populateQuickCommandsList(settings);
       
+    }
+
+ /**
+   * Populate the quick commands list
+   */
+  private populateQuickCommandsList(settings: any): void {
+    if (!this.quickCommandsContainer) return;
+    
+    this.quickCommandsContainer.empty();
       // Get all available statuses from service
       const allStatuses = this.getAllAvailableStatuses(settings);
       const currentQuickCommands = settings.quickStatusCommands || [];
   
       allStatuses.forEach(status => {
-        const setting = new Setting(quickCommandsContainer)
+        const setting = new Setting(this.quickCommandsContainer)
           .setName(`${status.icon} ${status.name}`)
           .addToggle(toggle => toggle
             .setValue(currentQuickCommands.includes(status.name))
@@ -206,12 +218,22 @@ export class NoteStatusSettingsUI {
       });
   
       if (allStatuses.length === 0) {
-        quickCommandsContainer.createDiv({
+        this.quickCommandsContainer.createDiv({
           text: 'No statuses available. Enable templates or add custom statuses first.',
           cls: 'setting-item-description'
         });
       }
     }
+  /**
+   * Refresh the quick commands list when statuses change
+   */
+  private refreshQuickCommandsList(settings: any): void {
+    // Add small delay to ensure settings are updated
+    setTimeout(() => {
+      this.populateQuickCommandsList(settings);
+    }, 50);
+  }
+
 /**
    * Get all available statuses from templates and custom statuses
    */
@@ -249,7 +271,11 @@ export class NoteStatusSettingsUI {
       .setDesc('Ignore template statuses and use only the custom statuses defined below')
       .addToggle(toggle => toggle
         .setValue(settings.useCustomStatusesOnly || false)
-        .onChange(value => this.callbacks.onSettingChange('useCustomStatusesOnly', value)));
+        .onChange(async (value) => {
+          await this.callbacks.onSettingChange('useCustomStatusesOnly', value);
+          // Update quick commands list when custom-only mode changes
+          this.refreshQuickCommandsList(settings);
+        }));
     
     const statusList = containerEl.createDiv({ cls: 'custom-status-list' });
     this.renderCustomStatuses(statusList, settings);
@@ -260,7 +286,10 @@ export class NoteStatusSettingsUI {
       .addButton(button => button
         .setButtonText('Add Status')
         .setCta()
-        .onClick(() => this.callbacks.onCustomStatusAdd()));
+        .onClick(async () => {
+          await this.callbacks.onCustomStatusAdd();
+          this.refreshQuickCommandsList(settings);
+        }));
   }
 
   /**
@@ -277,12 +306,19 @@ export class NoteStatusSettingsUI {
       setting.addText(text => text
         .setPlaceholder('Name')
         .setValue(status.name)
-        .onChange(value => this.callbacks.onCustomStatusChange(index, 'name', value || 'unnamed')));
+        .onChange(async (value) => {
+          await this.callbacks.onCustomStatusChange(index, 'name', value || 'unnamed');
+          // Update quick commands list when status name changes
+          this.refreshQuickCommandsList(settings);
+        }));
 
       setting.addText(text => text
         .setPlaceholder('Icon')
         .setValue(status.icon)
-        .onChange(value => this.callbacks.onCustomStatusChange(index, 'icon', value || '❓')));
+        .onChange(async (value) => {
+          await this.callbacks.onCustomStatusChange(index, 'icon', value || '❓');
+          this.refreshQuickCommandsList(settings);
+        }));
 
       setting.addColorPicker(colorPicker => colorPicker
         .setValue(settings.statusColors[status.name] || '#ffffff')
@@ -291,13 +327,19 @@ export class NoteStatusSettingsUI {
       setting.addText(text => text
         .setPlaceholder('Description')
         .setValue(status.description || '')
-        .onChange(value => this.callbacks.onCustomStatusChange(index, 'description', value)));
+        .onChange(async (value) => {
+          await this.callbacks.onCustomStatusChange(index, 'description', value);
+          this.refreshQuickCommandsList(settings);
+        }));
 
       setting.addButton(button => button
         .setButtonText('Remove')
         .setClass('status-remove-button')
         .setWarning()
-        .onClick(() => this.callbacks.onCustomStatusRemove(index)));
+        .onClick(async () => {
+          await this.callbacks.onCustomStatusRemove(index);
+          this.refreshQuickCommandsList(settings);
+        }));
     });
   }
 }

--- a/main.ts
+++ b/main.ts
@@ -207,6 +207,7 @@ onunload() {
   this.workspaceIntegration?.unload();
   this.metadataIntegration?.unload();
   this.editorIntegration?.unload();
+  this.commandIntegration?.unload();
   
   // Clean up services
   this.styleService?.unload();

--- a/models/types.ts
+++ b/models/types.ts
@@ -28,6 +28,7 @@ export interface NoteStatusSettings {
     tagPrefix: string; // Prefix for the status tag (default: 'status')
     strictStatuses: boolean; // Whether to only show known statuses
     excludeUnknownStatus: boolean; // Whether to exclude files with unknown status from the status pane
+    quickStatusCommands: string[];
 }
 
 /**


### PR DESCRIPTION
### Bug Fix
- Fixed "Add status to current note" command that was failing silently when multiple statuses mode was disabled
- Command now properly handles both single status mode (replace) and multiple status mode (add)
- Added proper mode parameter to dropdown opening logic

### New Feature: Quick Status Commands

- Added "Quick status commands" setting to select which statuses get dedicated commands
- Generates "Set status to {status}" commands for selected statuses
- Generates "Toggle status {status}" commands when multiple statuses mode is enabled
- Commands are dynamically registered/unregistered when settings change
- Settings UI automatically updates when templates or custom statuses change
![image](https://github.com/user-attachments/assets/ac7b467a-28ba-41d3-a3cc-6ae0b5b32de5)
![image](https://github.com/user-attachments/assets/e0f3440c-d6ab-44c0-8695-eff51c19543c)


