### PR TITLE
feat: disable dashboard and grouped views for large vaults (workaround for performance issues)

### DIFF
--- a/components/SettingsUI.tsx/BehaviourSettings.tsx
+++ b/components/SettingsUI.tsx/BehaviourSettings.tsx
@@ -52,6 +52,21 @@ export const BehaviourSettings: React.FC<Props> = ({ settings, onChange }) => {
 					}
 				/>
 			</SettingItem>
+
+			<SettingItem
+				name="Vault size limit"
+				description="Disable dashboard and grouped view for vaults with more notes than this limit to improve performance. Set to 0 to disable this feature."
+			>
+				<input
+					type="number"
+					min="0"
+					value={settings.vaultSizeLimit || 15000}
+					onChange={(e) => {
+						const value = parseInt(e.target.value) || 15000;
+						onChange("vaultSizeLimit", value);
+					}}
+				/>
+			</SettingItem>
 		</div>
 	);
 };

--- a/constants/defaultSettings.ts
+++ b/constants/defaultSettings.ts
@@ -27,4 +27,5 @@ export const DEFAULT_PLUGIN_SETTINGS: PluginSettings = {
 	statusBarNoStatusText: "No status",
 	statusBarShowNoStatusIcon: false,
 	statusBarShowNoStatusText: true,
+	vaultSizeLimit: 15000, // Disable dashboard and grouped view for vaults with more notes than this limit
 };

--- a/integrations/views/grouped-status-view.tsx
+++ b/integrations/views/grouped-status-view.tsx
@@ -151,7 +151,8 @@ export class GroupedStatusView extends ItemView {
 					key === "useCustomStatusesOnly" ||
 					key === "customStatuses" ||
 					key === "useMultipleStatuses" ||
-					key === "strictStatuses"
+					key === "strictStatuses" ||
+					key === "vaultSizeLimit"
 				) {
 					onDataChange();
 				}
@@ -180,6 +181,19 @@ export class GroupedStatusView extends ItemView {
 		const container = this.containerEl.children[1];
 		container.empty();
 		container.addClass("grouped-status-view-container");
+
+		// Check if vault exceeds the size limit
+		const files = BaseNoteStatusService.app.vault.getMarkdownFiles();
+		const vaultSizeLimit = settingsService.settings.vaultSizeLimit || 15000;
+
+		if (vaultSizeLimit > 0 && files.length > vaultSizeLimit) {
+			// Show disabled message
+			container.createEl("div", {
+				cls: "grouped-status-view-disabled",
+				text: `Grouped Status View disabled: Vault has ${files.length} notes (limit: ${vaultSizeLimit}). You can adjust this limit in plugin settings.`,
+			});
+			return;
+		}
 
 		this.root = createRoot(container);
 		this.root.render(

--- a/integrations/views/status-dashboard-view.tsx
+++ b/integrations/views/status-dashboard-view.tsx
@@ -304,6 +304,19 @@ export class StatusDashboardView extends ItemView {
 		container.empty();
 		container.addClass("status-dashboard-view-container");
 
+		// Check if vault exceeds the size limit
+		const files = this.app.vault.getMarkdownFiles();
+		const vaultSizeLimit = settingsService.settings.vaultSizeLimit || 15000;
+
+		if (vaultSizeLimit > 0 && files.length > vaultSizeLimit) {
+			// Show disabled message
+			container.createEl("div", {
+				cls: "status-dashboard-disabled",
+				text: `Dashboard disabled: Vault has ${files.length} notes (limit: ${vaultSizeLimit}). You can adjust this limit in plugin settings.`,
+			});
+			return;
+		}
+
 		this.root = createRoot(container);
 
 		// Set up event listeners
@@ -334,7 +347,8 @@ export class StatusDashboardView extends ItemView {
 					key === "useCustomStatusesOnly" ||
 					key === "customStatuses" ||
 					key === "useMultipleStatuses" ||
-					key === "strictStatuses"
+					key === "strictStatuses" ||
+					key === "vaultSizeLimit"
 				) {
 					handleVaultChange();
 					handleFileChange();

--- a/styles/components/dashboard.css
+++ b/styles/components/dashboard.css
@@ -310,6 +310,21 @@
 	color: var(--text-muted);
 }
 
+.status-dashboard-disabled {
+	display: flex;
+	align-items: center;
+	justify-content: center;
+	height: 100%;
+	padding: var(--size-4-4);
+	text-align: center;
+	font-size: var(--font-ui-medium);
+	color: var(--text-muted);
+	background: var(--background-secondary);
+	border: 2px dashed var(--background-modifier-border);
+	border-radius: var(--radius-m);
+	margin: var(--size-4-4);
+}
+
 /* Scrollbar */
 .status-dashboard-content::-webkit-scrollbar {
 	width: var(--scrollbar-width);

--- a/styles/components/grouped-view.css
+++ b/styles/components/grouped-view.css
@@ -210,6 +210,21 @@
 	font-size: var(--font-ui-medium);
 }
 
+.grouped-status-view-disabled {
+	display: flex;
+	align-items: center;
+	justify-content: center;
+	height: 100%;
+	padding: var(--size-4-4);
+	text-align: center;
+	font-size: var(--font-ui-medium);
+	color: var(--text-muted);
+	background: var(--background-secondary);
+	border: 2px dashed var(--background-modifier-border);
+	border-radius: var(--radius-m);
+	margin: var(--size-4-4);
+}
+
 /* Scrollbar */
 .grouped-status-content::-webkit-scrollbar,
 .grouped-status-files-list::-webkit-scrollbar {

--- a/types/pluginSettings.ts
+++ b/types/pluginSettings.ts
@@ -30,5 +30,6 @@ export type PluginSettings = {
 	statusBarNoStatusText: string; // Custom text for status bar when no status
 	statusBarShowNoStatusIcon: boolean; // Whether to show icon in status bar for no status
 	statusBarShowNoStatusText: boolean; // Whether to show text in status bar for no status
+	vaultSizeLimit: number; // Disable dashboard and grouped view for vaults with more notes than this limit
 	[key: string]: unknown;
 };


### PR DESCRIPTION
## What

This PR introduces a workaround to improve performance in large vaults by disabling the **Status Dashboard** and **Grouped Status View** when the number of notes exceeds a configurable limit (`vaultSizeLimit`, default: 15000).

A setting is added in the plugin options to customize this threshold, or disable the check by setting it to `0`.

## Why

Vaults with a high number of notes cause performance degradation when rendering the dashboard or grouped views. This PR prevents rendering them entirely in such cases as a temporary mitigation.

## How

- Added `vaultSizeLimit` setting (default: 15000).
- In both `status-dashboard-view` and `grouped-status-view`, added early return if vault size exceeds the threshold.
- Rendered a user-friendly message instead.
- Updated settings UI and styling to support the new option.

## Caveats

This is a workaround — it **does not solve the root performance problem**, only avoids the UI impact in large vaults.

---

**Issue created** to track the real solution: Improve dashboard performance in large vaults.

Closes   https://github.com/devonthesofa/obsidian-note-status/issues/45