### PR TITLE
[feature] Add setting to store status as string or list

### DIFF
--- a/components/SettingsUI/BehaviourSettings.tsx
+++ b/components/SettingsUI/BehaviourSettings.tsx
@@ -26,6 +26,26 @@ export const BehaviourSettings: React.FC<Props> = ({ settings, onChange }) => {
 			</SettingItem>
 
 			<SettingItem
+				name="Single status format"
+				description="Choose how the status frontmatter value is stored when multiple statuses are disabled. String format improves compatibility with plugins like TaskNotes."
+			>
+				<select
+					disabled={settings.useMultipleStatuses}
+					value={settings.singleStatusStorageMode || "list"}
+					onChange={(e) =>
+						onChange(
+							"singleStatusStorageMode",
+							e.target
+								.value as PluginSettings["singleStatusStorageMode"],
+						)
+					}
+				>
+					<option value="list">List (status: [in-progress])</option>
+					<option value="string">String (status: in-progress)</option>
+				</select>
+			</SettingItem>
+
+			<SettingItem
 				name="Apply status recursively to subfolders"
 				description="Show a folder context menu option that also processes notes inside nested folders."
 			>

--- a/constants/defaultSettings.ts
+++ b/constants/defaultSettings.ts
@@ -25,6 +25,7 @@ export const DEFAULT_PLUGIN_SETTINGS: PluginSettings = {
 	enabledTemplates: DEFAULT_ENABLED_TEMPLATES,
 	useCustomStatusesOnly: false,
 	useMultipleStatuses: true,
+	singleStatusStorageMode: "list",
 	statusBarShowTemplateName: "auto", // Default to show template names only when needed
 	tagPrefix: "obsidian-note-status",
 	strictStatuses: false, // Default to show all statuses from frontmatter

--- a/types/pluginSettings.ts
+++ b/types/pluginSettings.ts
@@ -26,6 +26,7 @@ export type PluginSettings = {
 	enabledTemplates: string[]; // IDs of enabled templates
 	useCustomStatusesOnly: boolean; // Whether to use only custom statuses or include templates
 	useMultipleStatuses: boolean; // Whether to allow multiple statuses per note
+	singleStatusStorageMode: "list" | "string"; // How to store single statuses when multiple statuses are disabled
 	tagPrefix: string; // Prefix for the status tag (default: 'status')
 	strictStatuses: boolean; // Whether to only show known statuses
 	quickStatusCommands: string[];


### PR DESCRIPTION
Adds a new setting that lets users choose how the status frontmatter is saved when multiple statuses are disabled.

Options:
- Store as string (status: in-progress)
- Store as list (status: [in-progress])

When multiple statuses are enabled, the plugin continues to always write a list.

Reading logic accepts both formats and normalizes internally. No automatic migration is performed; notes are rewritten only when the status changes.