### PR TITLE
[feature] Status for the non-markdown files

### DIFF
--- a/README.md
+++ b/README.md
@@ -160,6 +160,8 @@ Works with:
 - **QuickAdd macros**
 - **Global search**
 
+Non-Markdown files (PDF, Canvas, images, etc.) can't host YAML frontmatter. Their statuses live in a lightweight JSON file under `.obsidian/plugins/obsidian-note-status/non-markdown-statuses.json`, and every command/view in the plugin reads from that store transparently. External tools such as Dataview or Templater still only see Markdown/frontmatter data, so keep using Markdown files if you need those integrations.
+
 ## 🛠️ API Reference
 
 For developers building integrations or contributing:

--- a/core/eventBus.ts
+++ b/core/eventBus.ts
@@ -4,7 +4,7 @@ class EventBus {
 	private events: { [K in EventName]: Map<string, EventBusEvents[K]> } = {
 		"active-file-change": new Map(),
 		"plugin-settings-changed": new Map(),
-		"frontmatter-manually-changed": new Map(),
+		"status-changed": new Map(),
 		"triggered-open-modal": new Map(),
 	};
 
@@ -32,8 +32,8 @@ class EventBus {
 		...args: Parameters<EventBusEvents["plugin-settings-changed"]>
 	): void;
 	publish(
-		event: "frontmatter-manually-changed",
-		...args: Parameters<EventBusEvents["frontmatter-manually-changed"]>
+		event: "status-changed",
+		...args: Parameters<EventBusEvents["status-changed"]>
 	): void;
 	publish(
 		event: "triggered-open-modal",

--- a/core/statusStoreManager.ts
+++ b/core/statusStoreManager.ts
@@ -1,0 +1,37 @@
+import { Plugin, TFile } from "obsidian";
+import { FrontmatterStatusStore } from "./statusStores/frontmatterStatusStore";
+import { NonMarkdownStatusStore } from "./statusStores/nonMarkdownStatusStore";
+import { StatusStore } from "./statusStores/types";
+
+class StatusStoreManager {
+	private stores: StatusStore[] = [];
+
+	async initialize(plugin: Plugin) {
+		const frontmatterStore = new FrontmatterStatusStore(plugin.app);
+		this.stores = [frontmatterStore];
+
+		const nonMarkdownStore = new NonMarkdownStatusStore(plugin);
+		await nonMarkdownStore.initialize();
+		this.registerStore(nonMarkdownStore);
+	}
+
+	registerStore(store: StatusStore) {
+		this.stores.push(store);
+	}
+
+	getStoreForFile(file: TFile): StatusStore {
+		const store = this.stores.find((candidate) =>
+			candidate.canHandle(file),
+		);
+
+		if (!store) {
+			throw new Error(
+				`No status store registered for file type: ${file.extension}`,
+			);
+		}
+
+		return store;
+	}
+}
+
+export default new StatusStoreManager();

--- a/core/statusStores/frontmatterStatusStore.ts
+++ b/core/statusStores/frontmatterStatusStore.ts
@@ -1,0 +1,80 @@
+import { App, TFile } from "obsidian";
+import { StatusMutation, StatusStore } from "./types";
+
+export class FrontmatterStatusStore implements StatusStore {
+	constructor(private readonly app: App) {}
+
+	canHandle(file: TFile): boolean {
+		return file.extension === "md";
+	}
+
+	getStatuses(file: TFile, frontmatterTagName: string): string[] {
+		const cachedMetadata = this.app.metadataCache.getFileCache(file);
+		const frontmatter = cachedMetadata?.frontmatter;
+		if (!frontmatter) return [];
+
+		return this.normalizeValue(frontmatter[frontmatterTagName]);
+	}
+
+	async mutateStatuses(
+		file: TFile,
+		frontmatterTagName: string,
+		mutator: (current: string[]) => StatusMutation,
+		options: { storeAsArray: boolean },
+	): Promise<boolean> {
+		let changed = false;
+		await this.app.fileManager.processFrontMatter(file, (frontmatter) => {
+			const currentStatuses = this.normalizeValue(
+				frontmatter?.[frontmatterTagName],
+			);
+			const mutation = mutator([...currentStatuses]);
+
+			if (!mutation.hasChanged) return;
+
+			this.writeStatuses(
+				frontmatter,
+				frontmatterTagName,
+				mutation.nextStatuses,
+				options.storeAsArray,
+			);
+			changed = true;
+		});
+		return changed;
+	}
+
+	private normalizeValue(value: unknown): string[] {
+		if (!value) return [];
+		if (Array.isArray(value)) {
+			return value
+				.map((status) =>
+					status === undefined || status === null
+						? undefined
+						: String(status),
+				)
+				.filter((status): status is string => Boolean(status));
+		}
+		return [String(value)];
+	}
+
+	private writeStatuses(
+		frontmatter: Record<string, unknown>,
+		frontmatterTagName: string,
+		statuses: string[],
+		storeAsArray: boolean,
+	) {
+		if (!statuses.length) {
+			if (storeAsArray) {
+				frontmatter[frontmatterTagName] = [];
+			} else {
+				delete frontmatter[frontmatterTagName];
+			}
+			return;
+		}
+
+		if (storeAsArray) {
+			frontmatter[frontmatterTagName] = [...statuses];
+		} else {
+			frontmatter[frontmatterTagName] = statuses[0];
+		}
+	}
+}

--- a/core/statusStores/nonMarkdownStatusStore.ts
+++ b/core/statusStores/nonMarkdownStatusStore.ts
@@ -1,0 +1,141 @@
+import { normalizePath, Plugin, TAbstractFile, TFile } from "obsidian";
+import eventBus from "@/core/eventBus";
+import { StatusMutation, StatusStore } from "./types";
+
+type FileStatusMap = Record<string, Record<string, string[]>>;
+
+type PersistedData = {
+	version: number;
+	files: FileStatusMap;
+};
+
+export class NonMarkdownStatusStore implements StatusStore {
+	private data: FileStatusMap = {};
+	private readonly dataPath: string;
+
+	constructor(private readonly plugin: Plugin) {
+		const configDir = this.plugin.app.vault.configDir;
+		const pluginDir = `${configDir}/plugins/${this.plugin.manifest.id}`;
+		this.dataPath = normalizePath(
+			`${pluginDir}/non-markdown-statuses.json`,
+		);
+	}
+
+	async initialize(): Promise<void> {
+		this.data = await this.loadFromDisk();
+		this.registerVaultEvents();
+	}
+
+	canHandle(file: TFile): boolean {
+		return file.extension !== "md";
+	}
+
+	getStatuses(file: TFile, frontmatterTagName: string): string[] {
+		const fileStatuses = this.data[file.path];
+		if (!fileStatuses) return [];
+		const statuses = fileStatuses[frontmatterTagName];
+		return statuses ? [...statuses] : [];
+	}
+
+	async mutateStatuses(
+		file: TFile,
+		frontmatterTagName: string,
+		mutator: (current: string[]) => StatusMutation,
+		_options: { storeAsArray: boolean },
+	): Promise<boolean> {
+		const fileStatuses = this.data[file.path] ?? {};
+		const current = fileStatuses[frontmatterTagName] ?? [];
+		const mutation = mutator([...current]);
+
+		if (!mutation.hasChanged) {
+			return false;
+		}
+
+		if (mutation.nextStatuses.length) {
+			if (!this.data[file.path]) {
+				this.data[file.path] = {};
+			}
+			this.data[file.path][frontmatterTagName] = [
+				...mutation.nextStatuses,
+			];
+		} else if (this.data[file.path]) {
+			delete this.data[file.path][frontmatterTagName];
+			if (Object.keys(this.data[file.path]).length === 0) {
+				delete this.data[file.path];
+			}
+		}
+
+		await this.persistData();
+		return true;
+	}
+
+	private async loadFromDisk(): Promise<FileStatusMap> {
+		try {
+			const raw = await this.plugin.app.vault.adapter.read(this.dataPath);
+			const parsed = JSON.parse(raw) as PersistedData;
+			if (parsed && typeof parsed === "object" && parsed.files) {
+				return parsed.files;
+			}
+		} catch {
+			// File may not exist yet or be malformed; start with empty dataset.
+		}
+		return {};
+	}
+
+	private async persistData(): Promise<void> {
+		const payload: PersistedData = {
+			version: 1,
+			files: this.data,
+		};
+		await this.ensureDirectoryExists();
+		await this.plugin.app.vault.adapter.write(
+			this.dataPath,
+			JSON.stringify(payload, null, 2),
+		);
+	}
+
+	private async ensureDirectoryExists(): Promise<void> {
+		const dir = this.dataPath.split("/").slice(0, -1).join("/");
+		if (!(await this.plugin.app.vault.adapter.exists(dir))) {
+			await this.plugin.app.vault.adapter.mkdir(dir);
+		}
+	}
+
+	private registerVaultEvents() {
+		this.plugin.registerEvent(
+			this.plugin.app.vault.on("rename", (file, oldPath) => {
+				this.handleRename(file, oldPath);
+			}),
+		);
+
+		this.plugin.registerEvent(
+			this.plugin.app.vault.on("delete", (file) => {
+				this.handleDelete(file);
+			}),
+		);
+	}
+
+	private handleRename(file: TAbstractFile, oldPath: string) {
+		if (!(file instanceof TFile)) return;
+		const existing = this.data[oldPath];
+		if (!existing) return;
+		this.data[file.path] = existing;
+		delete this.data[oldPath];
+		this.persistData()
+			.then(() => {
+				eventBus.publish("status-changed", { file });
+			})
+			.catch(console.error);
+	}
+
+	private handleDelete(file: TAbstractFile) {
+		if (!(file instanceof TFile)) return;
+		if (!this.data[file.path]) return;
+		delete this.data[file.path];
+		this.persistData()
+			.then(() => {
+				eventBus.publish("status-changed", { file });
+			})
+			.catch(console.error);
+	}
+}

--- a/core/statusStores/types.ts
+++ b/core/statusStores/types.ts
@@ -1,0 +1,18 @@
+import { TFile } from "obsidian";
+
+export type StatusMutation =
+	| { hasChanged: false }
+	| { hasChanged: true; nextStatuses: string[] };
+
+export type StatusMutator = (current: string[]) => StatusMutation;
+
+export interface StatusStore {
+	canHandle(file: TFile): boolean;
+	getStatuses(file: TFile, frontmatterTagName: string): string[];
+	mutateStatuses(
+		file: TFile,
+		frontmatterTagName: string,
+		mutator: StatusMutator,
+		options: { storeAsArray: boolean },
+	): Promise<boolean>;
+}

--- a/integrations/modals/statusModalIntegration.tsx
+++ b/integrations/modals/statusModalIntegration.tsx
@@ -35,7 +35,7 @@ export class StatusModalIntegration extends Modal {
 		);
 
 		eventBus.subscribe(
-			"frontmatter-manually-changed",
+			"status-changed",
 			() => {
 				// TODO: There are multiple calls to populateStatuses, in this case the noteStatusService is passed by reference, so redundant computations
 				// FIXME: Line 27
@@ -141,7 +141,7 @@ export class StatusModalIntegration extends Modal {
 		StatusModalIntegration.instance = null;
 
 		eventBus.unsubscribe(
-			"frontmatter-manually-changed",
+			"status-changed",
 			"statusModalIntegrationSubscription1",
 		);
 	}

--- a/integrations/toolbar/editorToolbarIntegration.tsx
+++ b/integrations/toolbar/editorToolbarIntegration.tsx
@@ -98,7 +98,7 @@ export class EditorToolbarIntegration {
 		);
 
 		eventBus.subscribe(
-			"frontmatter-manually-changed",
+			"status-changed",
 			({ file }) => {
 				// Find the button for the specific file and refresh only that one
 				for (const [leaf, leafButton] of this.leafButtons.entries()) {
@@ -394,7 +394,7 @@ export class EditorToolbarIntegration {
 			"editorToolbarIntegrationSubscription2",
 		);
 		eventBus.unsubscribe(
-			"frontmatter-manually-changed",
+			"status-changed",
 			"editorToolbarIntegrationSubscription3",
 		);
 

--- a/types/eventBus.ts
+++ b/types/eventBus.ts
@@ -16,7 +16,7 @@ export type EventBusEvents = {
 		value: unknown;
 		currentSettings: PluginSettings;
 	}) => void;
-	"frontmatter-manually-changed": ({ file }: { file: TFile }) => void;
+	"status-changed": ({ file }: { file: TFile }) => void;
 	"triggered-open-modal": ({
 		statusService,
 	}: {


### PR DESCRIPTION
- Support storing statuses for every Obsidian file type by adding a pluggable storage layer: Markdown keeps using frontmatter while non‑Markdown files serialize to .obsidian/plugins/obsidian-note-status/non-markdown-statuses.json, with rename/delete hooks keeping data in sync.
- Refactor NoteStatusService and consumer integrations (status bar, toolbar, modals, explorers, dashboards, folder/context flows) so they read/write via the store abstraction and react to a unified status-changed event.

