### PR TITLE
feat: add support for default status on new notes

### DIFF
--- a/components/SettingsUI/BehaviourSettings.tsx
+++ b/components/SettingsUI/BehaviourSettings.tsx
@@ -1,7 +1,8 @@
 import { PluginSettings } from "@/types/pluginSettings";
-import React from "react";
+import React, { useMemo } from "react";
 import { SettingItem } from "./SettingItem";
 import { FrontmatterMappingsSettings } from "./FrontmatterMappingsSettings";
+import { BaseNoteStatusService } from "@/core/noteStatusService";
 
 export type Props = {
 	settings: PluginSettings;
@@ -9,9 +10,50 @@ export type Props = {
 };
 
 export const BehaviourSettings: React.FC<Props> = ({ settings, onChange }) => {
+	const availableStatuses = useMemo(() => {
+		return BaseNoteStatusService.getAllAvailableStatuses();
+	}, [
+		settings.templates,
+		settings.customStatuses,
+		settings.enabledTemplates,
+	]);
+
 	return (
 		<div>
 			<h3>Status tag</h3>
+
+			<SettingItem
+				name="Default status for new notes"
+				description="Automatically apply this status to newly created notes."
+			>
+				<select
+					value={settings.defaultStatusForNewNotes || ""}
+					onChange={(e) => {
+						const value = e.target.value;
+						onChange(
+							"defaultStatusForNewNotes",
+							value === "" ? null : value,
+						);
+					}}
+				>
+					<option value="">None</option>
+					{availableStatuses.map((status) => {
+						const identifier =
+							BaseNoteStatusService.formatStatusIdentifier({
+								templateId: status.templateId,
+								name: status.name,
+							});
+						const displayName = status.templateId
+							? `${status.name} (${status.templateId})`
+							: status.name;
+						return (
+							<option key={identifier} value={identifier}>
+								{displayName}
+							</option>
+						);
+					})}
+				</select>
+			</SettingItem>
 
 			<SettingItem
 				name="Enable multiple statuses"

--- a/constants/defaultSettings.ts
+++ b/constants/defaultSettings.ts
@@ -68,4 +68,5 @@ export const DEFAULT_PLUGIN_SETTINGS: PluginSettings = {
 	],
 	enableNonMarkdownSync: false,
 	nonMarkdownSyncPath: "_note-status-data.json",
+	defaultStatusForNewNotes: null,
 };

--- a/core/settingsService.ts
+++ b/core/settingsService.ts
@@ -39,6 +39,7 @@ export const SETTINGS_GROUPS: Record<SyncGroup, (keyof PluginSettings)[]> = {
 		"singleStatusStorageMode",
 		"strictStatuses",
 		"enableStatusOverviewPopup",
+		"defaultStatusForNewNotes",
 	],
 	storage: [
 		"tagPrefix",

--- a/main.tsx
+++ b/main.tsx
@@ -3,7 +3,10 @@ import StatusBarIntegration from "integrations/status-bar/status-bar";
 import eventBus from "core/eventBus";
 import { PluginSettingIntegration } from "./integrations/settings/pluginSettings";
 import settingsService from "./core/settingsService";
-import { BaseNoteStatusService } from "./core/noteStatusService";
+import {
+	BaseNoteStatusService,
+	NoteStatusService,
+} from "./core/noteStatusService";
 import { StatusModalIntegration } from "./integrations/modals/statusModalIntegration";
 import ContextMenuIntegration from "./integrations/context-menu/contextMenuIntegration";
 import { FileExplorerIntegration } from "./integrations/file-explorer/file-explorer-integration";
@@ -238,6 +241,42 @@ export default class NoteStatusPlugin extends Plugin {
 				}
 			},
 			"main-status-popup-setting-subscriptor",
+		);
+
+		this.registerEvent(
+			this.app.vault.on("create", async (file) => {
+				if (
+					file instanceof TFile &&
+					file.extension === "md" &&
+					settingsService.settings.defaultStatusForNewNotes
+				) {
+					// Wait a bit to ensure metadata is processed or templates are applied
+					setTimeout(async () => {
+						// Ensure file still exists
+						if (!this.app.vault.getAbstractFileByPath(file.path)) {
+							return;
+						}
+
+						const noteStatusService = new NoteStatusService(file);
+						// Populate statuses to see if it already has any
+						noteStatusService.populateStatuses();
+
+						const groupedStatuses =
+							noteStatusService.getStatusesByAllKeys();
+						const hasStatuses = Object.values(groupedStatuses).some(
+							(statuses) => statuses.length > 0,
+						);
+
+						if (!hasStatuses) {
+							await noteStatusService.addStatus(
+								settingsService.settings.tagPrefix,
+								settingsService.settings
+									.defaultStatusForNewNotes as string,
+							);
+						}
+					}, 500); // Increased delay to allow more time for templates
+				}
+			}),
 		);
 
 		this.registerEvent(

--- a/types/pluginSettings.ts
+++ b/types/pluginSettings.ts
@@ -84,5 +84,6 @@ export type PluginSettings = {
 	syncGroups: SyncGroup[]; // Selected groups of settings to synchronize
 	enableNonMarkdownSync: boolean; // Whether to sync non-markdown statuses to a vault file
 	nonMarkdownSyncPath: string; // Path to the non-markdown sync file
+	defaultStatusForNewNotes: string | null; // Default status to apply to new notes
 	[key: string]: unknown;
 };


### PR DESCRIPTION
  Changes Made

   1. Settings Extension: Added a new setting defaultStatusForNewNotes to the PluginSettings interface and initialized it to null.
   2. Settings UI: Added a "Default status for new notes" dropdown in the Behaviour settings section. This dropdown is populated with all currently enabled statuses
      (from both templates and custom statuses).
   3. Note Creation Listener: Integrated a new event listener in main.tsx that monitors the creation of markdown files. When a new note is created:
       * It waits briefly (500ms) to allow Obsidian and other plugins (like Templater) to finish initializing the file.
       * It checks if the note already has a status.
       * If no status is found, it automatically applies the configured default status.
   4. Synchronization: Added the new setting to the "Workflow" synchronization group so it can be synced across devices.
   5. Refactoring & Cleanup: Fixed minor mixed spaces and tabs issues in the settings type definitions that were causing lint errors